### PR TITLE
Pre-allocate memory stream, so the cost of it's creation is not included in the benchmark

### DIFF
--- a/src/Microsoft.ManagedZLib/benchmarks/ManagedZLibBenchmarks.cs
+++ b/src/Microsoft.ManagedZLib/benchmarks/ManagedZLibBenchmarks.cs
@@ -23,12 +23,14 @@ public class ManagedZLibBenchmark
     }
 
     public CompressedFile? CompressedFile;
+    private MemoryStream _outputStream;
 
     [GlobalSetup]
     public void Setup()
     {
         Debug.Assert(File != null);
         CompressedFile = new CompressedFile(File, Level);
+        _outputStream = new MemoryStream(UncompressedData.Length); 
     }
 
 
@@ -45,23 +47,23 @@ public class ManagedZLibBenchmark
     public void Cleanup() => CompressedFile?.CompressedDataStream.Dispose();
 
     [Benchmark(Baseline = true)]
-    public int DecompressNative()
+    public void DecompressNative()
     {
         CompressedFile!.CompressedDataStream.Position = 0;
-        MemoryStream expectedStream = new();
+        _outputStream.Position = 0;
+        
         System.IO.Compression.DeflateStream decompressor = new System.IO.Compression.DeflateStream(CompressedFile.CompressedDataStream, System.IO.Compression.CompressionMode.Decompress);
-        decompressor.CopyTo(expectedStream);
-        return 0;
+        decompressor.CopyTo(_outputStream);
     }
 
     [Benchmark]
-    public int DecompressManaged()
+    public void DecompressManaged()
     {
         CompressedFile!.CompressedDataStream.Position = 0;
-        MemoryStream expectedStream = new();
+        _outputStream.Position = 0;
+
         DeflateStream decompressor = new DeflateStream(CompressedFile.CompressedDataStream, CompressionMode.Decompress);
-        decompressor.CopyTo(expectedStream);
-        return 0;
+        decompressor.CopyTo(_outputStream);
     }
 
     public class ProgramRun


### PR DESCRIPTION
Once we do that, the benchmark will contain only the cost of creating the `DeflateStream` and the actual decompression.

In the future it will help us to narrow down the perf difference between managed and native implementation (there will be fewer things in the trace to look at)