### PR TITLE
Benchmark improvements

### DIFF
--- a/src/Microsoft.ManagedZLib/benchmarks/ManagedZLibBenchmarks.cs
+++ b/src/Microsoft.ManagedZLib/benchmarks/ManagedZLibBenchmarks.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Diagnostics.Windows.Configs;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
+using Perfolizer.Horology;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -69,7 +72,19 @@ public class ManagedZLibBenchmark
 
     public class ProgramRun
     {
-        public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(ProgramRun).Assembly).Run(args);
+        public static void Main(string[] args)
+        {
+            var job = Job.Default
+                .WithWarmupCount(1) // 1 warmup is enough for our purpose
+                .WithIterationTime(TimeInterval.FromMilliseconds(250)) // the default is 0.5s per iteration, which is slightly too much for us
+                .WithMinIterationCount(15)
+                .WithMaxIterationCount(20); // we don't want to run more that 20 iterations
+
+            var config = DefaultConfig.Instance
+                .AddJob(job.AsDefault());
+
+            BenchmarkSwitcher.FromAssembly(typeof(ProgramRun).Assembly).Run(args, config);
+        }
     }
 
 }

--- a/src/Microsoft.ManagedZLib/benchmarks/ManagedZLibBenchmarks.cs
+++ b/src/Microsoft.ManagedZLib/benchmarks/ManagedZLibBenchmarks.cs
@@ -3,8 +3,6 @@
 
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Diagnosers;
-using BenchmarkDotNet.Diagnostics.Windows.Configs;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using Perfolizer.Horology;
@@ -18,7 +16,6 @@ namespace Microsoft.ManagedZLib.Benchmarks;
 // BenchmarkDotNet creates a type which derives from type with benchmarks. 
 // So the type with benchmarks must not be sealed and it can NOT BE STATIC 
 // and it has to BE PUBLIC. It also has to be a class (no structs support).
-[EtwProfiler(performExtraBenchmarksRun: true)]
 public class ManagedZLibBenchmark
 {
     public static IEnumerable<string> UncompressedTestFileNames()

--- a/src/Microsoft.ManagedZLib/benchmarks/Microsoft.ManagedZLib.Benchmarks.csproj
+++ b/src/Microsoft.ManagedZLib/benchmarks/Microsoft.ManagedZLib.Benchmarks.csproj
@@ -11,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1" />
-	  <ProjectReference Include="..\src\Microsoft.ManagedZLib.csproj" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.6" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.6" />
+    <ProjectReference Include="..\src\Microsoft.ManagedZLib.csproj" />
     <PackageReference Include="System.IO.Compression.TestData" Version="8.0.0-beta.23326.1" />
   </ItemGroup>
 	


### PR DESCRIPTION
The first thing I did was trying to run with `--profiler ETW` which ended up producing an error:

![image](https://github.com/VivianaDuenas/runtimelab/assets/6011991/f828c55d-eeec-493e-b73c-f7f2b8fca790)

So I've set the version of both packages (it always must be the same) to `0.13.5` and got another one:

![image](https://github.com/VivianaDuenas/runtimelab/assets/6011991/ba6aee69-266f-4b7f-81f4-3f7b3005a88e)

Most likely `0.13.5` of `BenchmarkDotNet.Diagnostics.Windows` was simply not uploaded to our NuGet feed so I've updated it to `0.13.6` (in ideal world I would use `0.13.7`)

Then I run the benchmarks and they performed a LOT of iterations:

![image](https://github.com/VivianaDuenas/runtimelab/assets/6011991/3966d619-d0b9-473b-9111-cc3699f92dcc)

And took more than 3 minutes to run only two benchmarks:

![image](https://github.com/VivianaDuenas/runtimelab/assets/6011991/e2b296d3-f201-4497-9a8d-9105d2a12b84)

So I've copied the recommended settings from the performance repo:

https://github.com/dotnet/performance/blob/22b3b8d67fcaeaa71d6b00777615bb76da4addbc/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs#L33-L38

that basically tell BDN: run 1 warmup iteration, then stop the heuristic at 20 if it still believes the results are not stable. Now it takes +- 20 seconds to run them all.

Then I've removed the profiler attribute annotation (so it's not always enforced) and run with `--profiler ETW`:

It produced two trace files:

![image](https://github.com/VivianaDuenas/runtimelab/assets/6011991/a4524c77-ea17-4e92-a365-02e1483c79c3)

but the provided path was pointing to the "native" benchmark and I care about "managed" for now, so I've pointed PerfView to given folder, not file:

![image](https://github.com/VivianaDuenas/runtimelab/assets/6011991/f8425cdc-de7f-411b-829f-67ba8f457e47)

I've selected the benchmark process from the list (I've used the args to identify it)

![image](https://github.com/VivianaDuenas/runtimelab/assets/6011991/61ab9a33-917f-4e81-9a48-34e202dfc9a1)

I've disabled the grouping, there was a lot of unsolved symbols so I've selected everything (Ctrl+A), right clicked and solved the symbols. This gave me:

![image](https://github.com/VivianaDuenas/runtimelab/assets/6011991/ae5c5d7e-9b98-448a-ab73-e76e1b4d7943)

Then I went to the CallTree, searched for "actual" (to find the actual workload), right clicked and selected "Set Time Range" to filter the trace to actual benchmarking (I am not interested in warmup or the overhead):

![image](https://github.com/VivianaDuenas/runtimelab/assets/6011991/19def447-280d-4e05-8b09-bd44a2fe124d)

All the managed information was available:

![image](https://github.com/VivianaDuenas/runtimelab/assets/6011991/f903671b-33ad-46c2-9c75-3c8c83578faa)

![image](https://github.com/VivianaDuenas/runtimelab/assets/6011991/7cdb4433-d785-467d-a1b9-c2d8a94cdc76)

I did not dig any further as on my machine the managed implementation is 4x faster than native:

|            Method |        Level |             File |     Mean |    Error |   StdDev | Ratio | RatioSD |
|------------------ |------------- |----------------- |---------:|---------:|---------:|------:|--------:|
|  DecompressNative | SmallestSize | TestDocument.pdf | 42.67 us | 2.552 us | 2.836 us |  1.00 |    0.00 |
| DecompressManaged | SmallestSize | TestDocument.pdf | 12.06 us | 0.066 us | 0.062 us |  0.28 |    0.02 |



